### PR TITLE
Minor edits mentioned in OXT pull-request

### DIFF
--- a/rpc-broker/Makefile.am
+++ b/rpc-broker/Makefile.am
@@ -1,5 +1,5 @@
 AM_CFLAGS = -g -Wall -lpthread \
-	$(DBUS_CFLAGS) $(V4V_CFLAGS) $(LIBWEBSOCKETS_CFLAGS) \
+	$(DBUS_CFLAGS) $(LIBWEBSOCKETS_CFLAGS) \
     $(JSON_C_CFLAGS) $(LIBXML_CFLAGS) 
 
 sbin_PROGRAMS = rpc-broker
@@ -17,7 +17,6 @@ noinst_HEADERS = src/rpc-broker.h
 
 rpc_broker_LDADD = \
     $(DBUS_LIBS) \
-    $(LIBV4V_LIBS) \
     $(LIBWEBSOCKETS_LIBS) \
     $(JSON_C_LIBS) \
     $(LIBXML_LIBS) \

--- a/rpc-broker/src/dbus.c
+++ b/rpc-broker/src/dbus.c
@@ -251,16 +251,14 @@ DBusMessage *make_dbus_call(DBusConnection *conn, struct dbus_message *dmsg)
                                                 dmsg->args[i]);
                 break;
 
-            case ('b'): {
+            case ('b'): 
                 dbus_message_iter_append_basic(&iter, DBUS_TYPE_BOOLEAN,
                                                dmsg->args[i]);
                 break;
-            }
-
-            case ('v'): {
+            
+            case ('v'): 
                 append_variant(&iter, dmsg->json_sig[i], dmsg->args[i]);
                 break;
-            }
 
             default:
                 DBUS_BROKER_WARNING("<Invalid DBus Signature> [%c]",

--- a/rpc-broker/src/dbus.c
+++ b/rpc-broker/src/dbus.c
@@ -325,6 +325,35 @@ free_msg:
     return reply;
 }
 
+DBusMessage *db_list(void)
+{
+    DBusConnection *conn = create_dbus_connection();
+
+    if (!conn)
+        return NULL;
+
+    struct dbus_message dmsg;
+
+    dbus_default(&dmsg);
+    dmsg.member = DBUS_LIST;
+    dmsg.args[0] = (void *) DBUS_VM_PATH;
+
+    DBusMessage *vms = make_dbus_call(conn, &dmsg);
+
+    if (!vms && verbose_logging) {
+        DBUS_BROKER_WARNING("DBus message return error <db-list> %s", "");
+    } else if (vms && dbus_message_get_type(vms) == DBUS_MESSAGE_TYPE_ERROR) {
+        if (verbose_logging)
+            DBUS_BROKER_WARNING("DBus message return error <db-list> %s", "");
+        dbus_message_unref(vms);
+        vms = NULL;
+    }
+
+    dbus_connection_unref(conn);
+
+    return vms;
+}
+
 /*
  * For any given dbus request, this function will retrieve its corresponding
  * introspection information.

--- a/rpc-broker/src/dbus.c
+++ b/rpc-broker/src/dbus.c
@@ -80,42 +80,10 @@ int connect_to_system_bus(void)
     return srv;
 }
 
-/*
- * Used by client communications over port-5555 where, the raw-bytes are being
- * read directly from the client file-descriptor.  The `char` buffer is
- * de-marshalled into a dbus-protocol object `DBusMessage`
- */
-signed int convert_raw_dbus(struct dbus_message *dmsg,
-                            const char *msg, size_t len)
+static void debug_raw_msg(struct dbus_message *dmsg, DBusMessage *dbus_msg)
 {
-    DBusError error;
-    dbus_error_init(&error);
-
-    DBusMessage *dbus_msg = NULL;
-    dbus_msg = dbus_message_demarshal(msg, len, &error);
-
-    if (dbus_error_is_set(&error)) {
-        DBUS_BROKER_WARNING("<De-Marshal failed> [Length: %zu] error: %s",
-                              len, error.message);
-        return -1;
-    }
-
-    const char *destination = dbus_message_get_destination(dbus_msg);
-    dmsg->destination = destination ? destination : "NULL";
-
-    const char *path = dbus_message_get_path(dbus_msg);
-    dmsg->path = path ? path : "/";
-
-    const char *interface = dbus_message_get_interface(dbus_msg);
-    dmsg->interface = interface ? interface : "NULL";
-
-    const char *member = dbus_message_get_member(dbus_msg);
-    dmsg->member = member ? member : "NULL";
-
-    int ret = dbus_message_get_type(dbus_msg);
-/*
-    // XXX
-    DBUS_BROKER_EVENT("5555 %s %s %s %s", dmsg->destination, dmsg->path, dmsg->interface, dmsg->member);
+    DBUS_BROKER_EVENT("5555 %s %s %s %s", dmsg->destination, dmsg->path, 
+                                         dmsg->interface, dmsg->member);
     DBusMessageIter iter;
     dbus_message_iter_init(dbus_msg, &iter);
     int type;
@@ -150,14 +118,53 @@ signed int convert_raw_dbus(struct dbus_message *dmsg,
                 break;
             }
 
-            default:
+            default: {
                 DBUS_BROKER_EVENT("5555 other %d",  type);
                 break;
+            }
         }
 
         dbus_message_iter_next(&iter);
     }
-*/
+}
+
+/*
+ * Used by client communications over port-5555 where, the raw-bytes are being
+ * read directly from the client file-descriptor.  The `char` buffer is
+ * de-marshalled into a dbus-protocol object `DBusMessage`
+ */
+signed int convert_raw_dbus(struct dbus_message *dmsg,
+                            const char *msg, size_t len)
+{
+    DBusError error;
+    dbus_error_init(&error);
+
+    DBusMessage *dbus_msg = NULL;
+    dbus_msg = dbus_message_demarshal(msg, len, &error);
+
+    if (dbus_error_is_set(&error)) {
+        DBUS_BROKER_WARNING("<De-Marshal failed> [Length: %zu] error: %s",
+                              len, error.message);
+        return -1;
+    }
+
+    const char *destination = dbus_message_get_destination(dbus_msg);
+    dmsg->destination = destination ? destination : "NULL";
+
+    const char *path = dbus_message_get_path(dbus_msg);
+    dmsg->path = path ? path : "/";
+
+    const char *interface = dbus_message_get_interface(dbus_msg);
+    dmsg->interface = interface ? interface : "NULL";
+
+    const char *member = dbus_message_get_member(dbus_msg);
+    dmsg->member = member ? member : "NULL";
+
+    int ret = dbus_message_get_type(dbus_msg);
+
+#ifdef DEBUG
+    debug_raw_msg(dmsg, dbus_msg);
+#endif
 
     return ret;
 }

--- a/rpc-broker/src/dbus.c
+++ b/rpc-broker/src/dbus.c
@@ -251,12 +251,12 @@ DBusMessage *make_dbus_call(DBusConnection *conn, struct dbus_message *dmsg)
                                                 dmsg->args[i]);
                 break;
 
-            case ('b'): 
+            case ('b'):
                 dbus_message_iter_append_basic(&iter, DBUS_TYPE_BOOLEAN,
                                                dmsg->args[i]);
                 break;
-            
-            case ('v'): 
+
+            case ('v'):
                 append_variant(&iter, dmsg->json_sig[i], dmsg->args[i]);
                 break;
 

--- a/rpc-broker/src/json.c
+++ b/rpc-broker/src/json.c
@@ -86,34 +86,37 @@ static void append_dbus_message_arg(int type, int idx, void **args,
 
     switch (type) {
 
-        case ('b'): 
+        case ('b'): { 
             int json_bool = json_object_get_boolean(jarg);
             args[idx] = malloc(sizeof(int));
             memcpy(args[idx], (void *) &json_bool, sizeof(int));
             break;
+        }
 
         case ('u'):
-        case ('i'): 
+        case ('i'): { 
             int json_int = json_object_get_int(jarg);
             args[idx] = malloc(sizeof(int));
             memcpy(args[idx], (void *) &json_int, sizeof(int));
             break;
+        }
 
-        case ('s'): 
+        case ('s'): { 
             const char *json_str = json_object_get_string(jarg);
             args[idx] = malloc(strlen(json_str) + 1);
             if (json_str)
                 memcpy(args[idx], (void *) json_str, strlen(json_str) + 1);
             else
                 ((char *) args[idx])[0] = '\0';
-
             break;
+        }
 
-        case ('v'): 
+        case ('v'): { 
             int jtype = json_object_get_type(jarg);
             type = json_dbus_types[jtype];
             append_dbus_message_arg(type, idx, args, jarg);
             break;
+        }
 
         default:
             break;
@@ -149,11 +152,12 @@ void load_json_response(DBusMessage *msg, struct json_response *jrsp)
             case 'a':
             case 'i':
             case 's':
-            case 'o': 
+            case 'o': { 
                 struct json_object *array = json_object_new_array();
                 json_object_array_add(jrsp->args, array);
                 args = array;
                 break;
+            }
 
             default:
                 break;

--- a/rpc-broker/src/json.c
+++ b/rpc-broker/src/json.c
@@ -86,7 +86,7 @@ static void append_dbus_message_arg(int type, int idx, void **args,
 
     switch (type) {
 
-        case ('b'): { 
+        case ('b'): {
             int json_bool = json_object_get_boolean(jarg);
             args[idx] = malloc(sizeof(int));
             memcpy(args[idx], (void *) &json_bool, sizeof(int));
@@ -94,14 +94,14 @@ static void append_dbus_message_arg(int type, int idx, void **args,
         }
 
         case ('u'):
-        case ('i'): { 
+        case ('i'): {
             int json_int = json_object_get_int(jarg);
             args[idx] = malloc(sizeof(int));
             memcpy(args[idx], (void *) &json_int, sizeof(int));
             break;
         }
 
-        case ('s'): { 
+        case ('s'): {
             const char *json_str = json_object_get_string(jarg);
             args[idx] = malloc(strlen(json_str) + 1);
             if (json_str)
@@ -111,7 +111,7 @@ static void append_dbus_message_arg(int type, int idx, void **args,
             break;
         }
 
-        case ('v'): { 
+        case ('v'): {
             int jtype = json_object_get_type(jarg);
             type = json_dbus_types[jtype];
             append_dbus_message_arg(type, idx, args, jarg);
@@ -152,7 +152,7 @@ void load_json_response(DBusMessage *msg, struct json_response *jrsp)
             case 'a':
             case 'i':
             case 's':
-            case 'o': { 
+            case 'o': {
                 struct json_object *array = json_object_new_array();
                 json_object_array_add(jrsp->args, array);
                 args = array;

--- a/rpc-broker/src/json.c
+++ b/rpc-broker/src/json.c
@@ -146,8 +146,9 @@ void load_json_response(DBusMessage *msg, struct json_response *jrsp)
 
         dbus_message_iter_recurse(&iter, &sub);
         iter = sub;
-        // This accomodates the legacy code in `rpc-proxy` where thegc
-        // signatures are being mis-handled.
+        // This accomodates the legacy code in `rpc-proxy` where the
+        // signatures are being mis-handled and thus the UI is excpecting 
+        // the malformed dbus responses.
         switch (jrsp->arg_sig[1]) {
             case 'a':
             case 'i':

--- a/rpc-broker/src/json.c
+++ b/rpc-broker/src/json.c
@@ -86,22 +86,20 @@ static void append_dbus_message_arg(int type, int idx, void **args,
 
     switch (type) {
 
-        case ('b'): {
+        case ('b'): 
             int json_bool = json_object_get_boolean(jarg);
             args[idx] = malloc(sizeof(int));
             memcpy(args[idx], (void *) &json_bool, sizeof(int));
             break;
-        }
 
         case ('u'):
-        case ('i'): {
+        case ('i'): 
             int json_int = json_object_get_int(jarg);
             args[idx] = malloc(sizeof(int));
             memcpy(args[idx], (void *) &json_int, sizeof(int));
             break;
-        }
 
-        case ('s'): {
+        case ('s'): 
             const char *json_str = json_object_get_string(jarg);
             args[idx] = malloc(strlen(json_str) + 1);
             if (json_str)
@@ -110,14 +108,12 @@ static void append_dbus_message_arg(int type, int idx, void **args,
                 ((char *) args[idx])[0] = '\0';
 
             break;
-        }
 
-        case ('v'): {
+        case ('v'): 
             int jtype = json_object_get_type(jarg);
             type = json_dbus_types[jtype];
             append_dbus_message_arg(type, idx, args, jarg);
             break;
-        }
 
         default:
             break;
@@ -153,12 +149,11 @@ void load_json_response(DBusMessage *msg, struct json_response *jrsp)
             case 'a':
             case 'i':
             case 's':
-            case 'o': {
+            case 'o': 
                 struct json_object *array = json_object_new_array();
                 json_object_array_add(jrsp->args, array);
                 args = array;
                 break;
-            }
 
             default:
                 break;

--- a/rpc-broker/src/msg.c
+++ b/rpc-broker/src/msg.c
@@ -76,6 +76,21 @@ int broker(struct dbus_message *dmsg, int domid)
     return policy;
 }
 
+static void debug_raw_buffer(char *buf, int rbytes)
+{
+    char tmp[DBUS_MSG_LEN] = { '\0' };
+
+    int i;
+    for (i=0; i < rbytes; i++) {
+        if (isalnum(buf[i]))
+            tmp[i] = buf[i];
+        else
+            tmp[i] = '-';
+    }
+
+    DBUS_BROKER_EVENT("5555: %s", tmp);
+}
+
 /*
  * This is an opaque function to pass raw dbus-bytes back in forth between
  * sender and receiver.  Its opaque in the sense that the function is unaware
@@ -110,20 +125,9 @@ int exchange(int rsock, int ssock, int domid,
 //                    return -1;
             }
 
-/*
-            if (!dom0) {
-                char tmp[DBUS_MSG_LEN] = { '\0' };
-                int i;
-                for (i=0; i < rbytes; i++) {
-                    if (isalnum(buf[i]))
-                        tmp[i] = buf[i];
-                    else
-                        tmp[i] = '-';
-                }
-
-                DBUS_BROKER_EVENT("5555: %s", tmp);
-            }
-*/
+#ifdef DEBUG
+        debug_raw_buffer(buf, rbytes);
+#endif
         }
 
         total += rbytes;

--- a/rpc-broker/src/policy.c
+++ b/rpc-broker/src/policy.c
@@ -170,35 +170,6 @@ static void build_etc_policy(struct etc_policy *etc, const char *rule_filepath)
     close(policy_fd);
 }
 
-DBusMessage *db_list(void)
-{
-    DBusConnection *conn = create_dbus_connection();
-
-    if (!conn)
-        return NULL;
-
-    struct dbus_message dmsg;
-
-    dbus_default(&dmsg);
-    dmsg.member = DBUS_LIST;
-    dmsg.args[0] = (void *) DBUS_VM_PATH;
-
-    DBusMessage *vms = make_dbus_call(conn, &dmsg);
-
-    if (!vms && verbose_logging) {
-        DBUS_BROKER_WARNING("DBus message return error <db-list> %s", "");
-    } else if (vms && dbus_message_get_type(vms) == DBUS_MESSAGE_TYPE_ERROR) {
-        if (verbose_logging)
-            DBUS_BROKER_WARNING("DBus message return error <db-list> %s", "");
-        dbus_message_unref(vms);
-        vms = NULL;
-    }
-
-    dbus_connection_unref(conn);
-
-    return vms;
-}
-
 struct policy *build_policy(const char *rule_filename)
 {
     DBusMessage *vms = db_list();

--- a/rpc-broker/src/rpc-broker.c
+++ b/rpc-broker/src/rpc-broker.c
@@ -228,7 +228,7 @@ static void close_server_rawdbus(uv_handle_t *handle)
     free(server);
 }
 
-void service_rdconn_cb(uv_poll_t *handle, int status, int events)
+static void service_rdconn_cb(uv_poll_t *handle, int status, int events)
 {
     struct raw_dbus_conn *rdconn = (struct raw_dbus_conn *) handle->data;
 
@@ -238,7 +238,7 @@ void service_rdconn_cb(uv_poll_t *handle, int status, int events)
         uv_close((uv_handle_t *) handle, close_client_rawdbus);
 }
 
-void service_rawdbus_server(uv_poll_t *handle, int status, int events)
+static void service_rawdbus_server(uv_poll_t *handle, int status, int events)
 {
     struct dbus_broker_server *server = (struct dbus_broker_server *) handle->data;
     uv_loop_t *loop = server->mainloop;
@@ -291,7 +291,7 @@ void service_rawdbus_server(uv_poll_t *handle, int status, int events)
     }
 }
 
-void run_rawdbus(struct dbus_broker_args *args)
+static void run_rawdbus(struct dbus_broker_args *args)
 {
     struct dbus_broker_server *server = start_server(args->port);
     DBUS_BROKER_EVENT("<Server has started listening> [Port: %d]", args->port);

--- a/rpc-broker/src/rpc-broker.c
+++ b/rpc-broker/src/rpc-broker.c
@@ -242,7 +242,7 @@ void service_rawdbus_server(uv_poll_t *handle, int status, int events)
 {
     struct dbus_broker_server *server = (struct dbus_broker_server *) handle->data;
     uv_loop_t *loop = server->mainloop;
-   
+
     if (events & UV_READABLE) {
 	        socklen_t clilen = sizeof(server->peer);
 	        int client = accept(server->dbus_socket,

--- a/rpc-broker/src/rpc-broker.h
+++ b/rpc-broker/src/rpc-broker.h
@@ -41,7 +41,6 @@
 #include <xenstore.h>
 #endif
 
-#define DEBUG 0
 
 #define DBUS_BROKER_ERROR(call)                                       \
     do {                                                              \

--- a/rpc-broker/src/rpc-broker.h
+++ b/rpc-broker/src/rpc-broker.h
@@ -41,6 +41,7 @@
 #include <xenstore.h>
 #endif
 
+#define DEBUG 0
 
 #define DBUS_BROKER_ERROR(call)                                       \
     do {                                                              \

--- a/rpc-broker/src/rpc-broker.h
+++ b/rpc-broker/src/rpc-broker.h
@@ -267,8 +267,6 @@ signed int is_stubdom(uint16_t domid);
 
 void print_usage(void);
 
-void service_rdconns(void);
-
 void sigint_handler(int signal);
 
 
@@ -295,10 +293,6 @@ DBusMessage *db_list(void);
 char *dbus_introspect(struct json_request *jreq);
 
 void add_ws_signal(DBusConnection *conn, struct lws *wsi);
-
-void add_rdconn(int client, int domid);
-
-void remove_rdconn(struct raw_dbus_conn *conn);
 
 void free_dlinks(void);
 

--- a/rpc-broker/src/rpc-broker.h
+++ b/rpc-broker/src/rpc-broker.h
@@ -290,6 +290,8 @@ DBusMessage *make_dbus_call(DBusConnection *conn, struct dbus_message *dmsg);
 
 char *db_query(DBusConnection *conn, char *arg);
 
+DBusMessage *db_list(void);
+
 char *dbus_introspect(struct json_request *jreq);
 
 void add_ws_signal(DBusConnection *conn, struct lws *wsi);
@@ -341,8 +343,6 @@ int filter(struct rule *policy_rule, struct dbus_message *dmsg, uint16_t domid);
 
 
 // src/policy.c
-DBusMessage *db_list(void);
-
 struct policy *build_policy(const char *rule_filepath);
 
 void free_rule(struct rule r);

--- a/rpc-broker/src/signature.c
+++ b/rpc-broker/src/signature.c
@@ -178,47 +178,41 @@ void parse_signature(struct json_object *args, char *key, DBusMessageIter *iter)
                 break;
 
             case (DBUS_TYPE_OBJECT_PATH):
-            case (DBUS_TYPE_STRING): {
+            case (DBUS_TYPE_STRING): 
                 char *dbus_string;
                 dbus_message_iter_get_basic(iter, &dbus_string);
                 obj = json_object_new_string(dbus_string);
                 break;
-            }
 
             case (DBUS_TYPE_INT32):
-            case (DBUS_TYPE_UINT32): {
+            case (DBUS_TYPE_UINT32): 
                 int dbus_int;
                 dbus_message_iter_get_basic(iter, &dbus_int);
                 obj = json_object_new_int(dbus_int);
                 break;
-            }
 
-            case (DBUS_TYPE_DOUBLE): {
+            case (DBUS_TYPE_DOUBLE): 
                 double dbus_double;
                 dbus_message_iter_get_basic(iter, &dbus_double);
                 obj = json_object_new_double(dbus_double);
                 break;
-            }
 
-            case (DBUS_TYPE_BOOLEAN): {
+            case (DBUS_TYPE_BOOLEAN): 
                 int dbus_bool;
                 dbus_message_iter_get_basic(iter, &dbus_bool);
                 obj = json_object_new_boolean(dbus_bool);
                 break;
-            }
 
-            case (DBUS_TYPE_VARIANT): {
+            case (DBUS_TYPE_VARIANT): 
                 dbus_message_iter_recurse(iter, &sub);
                 parse_signature(args, key, &sub);
                 break;
-            }
 
-            case (DBUS_TYPE_INT64): {
+            case (DBUS_TYPE_INT64): 
                 uint64_t dbus_long;
                 dbus_message_iter_get_basic(iter, &dbus_long);
                 obj = json_object_new_int64(dbus_long);
                 break;
-            }
 
             default:
                 DBUS_BROKER_WARNING("<dbus signature unrecognized> [Type: %d]",

--- a/rpc-broker/src/signature.c
+++ b/rpc-broker/src/signature.c
@@ -180,7 +180,7 @@ void parse_signature(struct json_object *args, char *key, DBusMessageIter *iter)
             }
 
             case (DBUS_TYPE_OBJECT_PATH):
-            case (DBUS_TYPE_STRING): { 
+            case (DBUS_TYPE_STRING): {
                 char *dbus_string;
                 dbus_message_iter_get_basic(iter, &dbus_string);
                 obj = json_object_new_string(dbus_string);
@@ -188,34 +188,34 @@ void parse_signature(struct json_object *args, char *key, DBusMessageIter *iter)
             }
 
             case (DBUS_TYPE_INT32):
-            case (DBUS_TYPE_UINT32): { 
+            case (DBUS_TYPE_UINT32): {
                 int dbus_int;
                 dbus_message_iter_get_basic(iter, &dbus_int);
                 obj = json_object_new_int(dbus_int);
                 break;
             }
 
-            case (DBUS_TYPE_DOUBLE): { 
+            case (DBUS_TYPE_DOUBLE): {
                 double dbus_double;
                 dbus_message_iter_get_basic(iter, &dbus_double);
                 obj = json_object_new_double(dbus_double);
                 break;
             }
 
-            case (DBUS_TYPE_BOOLEAN): { 
+            case (DBUS_TYPE_BOOLEAN): {
                 int dbus_bool;
                 dbus_message_iter_get_basic(iter, &dbus_bool);
                 obj = json_object_new_boolean(dbus_bool);
                 break;
             }
 
-            case (DBUS_TYPE_VARIANT): { 
+            case (DBUS_TYPE_VARIANT): {
                 dbus_message_iter_recurse(iter, &sub);
                 parse_signature(args, key, &sub);
                 break;
             }
 
-            case (DBUS_TYPE_INT64): { 
+            case (DBUS_TYPE_INT64): {
                 uint64_t dbus_long;
                 dbus_message_iter_get_basic(iter, &dbus_long);
                 obj = json_object_new_int64(dbus_long);

--- a/rpc-broker/src/signature.c
+++ b/rpc-broker/src/signature.c
@@ -169,50 +169,58 @@ void parse_signature(struct json_object *args, char *key, DBusMessageIter *iter)
 
         switch (type) {
 
-            case (DBUS_TYPE_ARRAY):
+            case (DBUS_TYPE_ARRAY): {
                 add_json_array(args, key, iter);
                 break;
+            }
 
-            case (DBUS_TYPE_DICT_ENTRY):
+            case (DBUS_TYPE_DICT_ENTRY): {
                 parse_dbus_dict(args, key, iter);
                 break;
+            }
 
             case (DBUS_TYPE_OBJECT_PATH):
-            case (DBUS_TYPE_STRING): 
+            case (DBUS_TYPE_STRING): { 
                 char *dbus_string;
                 dbus_message_iter_get_basic(iter, &dbus_string);
                 obj = json_object_new_string(dbus_string);
                 break;
+            }
 
             case (DBUS_TYPE_INT32):
-            case (DBUS_TYPE_UINT32): 
+            case (DBUS_TYPE_UINT32): { 
                 int dbus_int;
                 dbus_message_iter_get_basic(iter, &dbus_int);
                 obj = json_object_new_int(dbus_int);
                 break;
+            }
 
-            case (DBUS_TYPE_DOUBLE): 
+            case (DBUS_TYPE_DOUBLE): { 
                 double dbus_double;
                 dbus_message_iter_get_basic(iter, &dbus_double);
                 obj = json_object_new_double(dbus_double);
                 break;
+            }
 
-            case (DBUS_TYPE_BOOLEAN): 
+            case (DBUS_TYPE_BOOLEAN): { 
                 int dbus_bool;
                 dbus_message_iter_get_basic(iter, &dbus_bool);
                 obj = json_object_new_boolean(dbus_bool);
                 break;
+            }
 
-            case (DBUS_TYPE_VARIANT): 
+            case (DBUS_TYPE_VARIANT): { 
                 dbus_message_iter_recurse(iter, &sub);
                 parse_signature(args, key, &sub);
                 break;
+            }
 
-            case (DBUS_TYPE_INT64): 
+            case (DBUS_TYPE_INT64): { 
                 uint64_t dbus_long;
                 dbus_message_iter_get_basic(iter, &dbus_long);
                 obj = json_object_new_int64(dbus_long);
                 break;
+            }
 
             default:
                 DBUS_BROKER_WARNING("<dbus signature unrecognized> [Type: %d]",

--- a/rpc-broker/src/websockets.c
+++ b/rpc-broker/src/websockets.c
@@ -41,16 +41,15 @@ static int ws_server_callback(struct lws *wsi, enum lws_callback_reasons reason,
 {
     switch (reason) {
 
-        case LWS_CALLBACK_RECEIVE: {
+        case LWS_CALLBACK_RECEIVE:
             memset(user, '\0', WS_USER_MEM_SIZE);
             memcpy(user, in, len);
             if (ws_request_handler(wsi, user) == 0)
                 lws_callback_on_writable(wsi);
 
             break;
-        }
 
-        case LWS_CALLBACK_SERVER_WRITEABLE: {
+        case LWS_CALLBACK_SERVER_WRITEABLE:
             if (lws_ring_get_count_waiting_elements(ring, NULL) > 0) {
                 char *rsp = (char *) lws_ring_get_element(ring, NULL);
                 lws_ring_consume(ring, NULL, NULL, 1);
@@ -61,7 +60,6 @@ static int ws_server_callback(struct lws *wsi, enum lws_callback_reasons reason,
             }
 
             break;
-        }
 
         case LWS_CALLBACK_PROTOCOL_INIT:
             DBUS_BROKER_EVENT("<WS client request> %s", "");

--- a/rpc-broker/src/websockets.c
+++ b/rpc-broker/src/websockets.c
@@ -41,15 +41,15 @@ static int ws_server_callback(struct lws *wsi, enum lws_callback_reasons reason,
 {
     switch (reason) {
 
-        case LWS_CALLBACK_RECEIVE:
+        case LWS_CALLBACK_RECEIVE: {
             memset(user, '\0', WS_USER_MEM_SIZE);
             memcpy(user, in, len);
             if (ws_request_handler(wsi, user) == 0)
                 lws_callback_on_writable(wsi);
-
             break;
+        }
 
-        case LWS_CALLBACK_SERVER_WRITEABLE:
+        case LWS_CALLBACK_SERVER_WRITEABLE: {
             if (lws_ring_get_count_waiting_elements(ring, NULL) > 0) {
                 char *rsp = (char *) lws_ring_get_element(ring, NULL);
                 lws_ring_consume(ring, NULL, NULL, 1);
@@ -58,18 +58,20 @@ static int ws_server_callback(struct lws *wsi, enum lws_callback_reasons reason,
                           strlen(rsp), LWS_WRITE_TEXT);
                 lws_callback_on_writable(wsi);
             }
-
             break;
+        }
 
-        case LWS_CALLBACK_PROTOCOL_INIT:
+        case LWS_CALLBACK_PROTOCOL_INIT: {
             DBUS_BROKER_EVENT("<WS client request> %s", "");
             break;
+        }
 
         case LWS_CALLBACK_CLOSED:
-        case LWS_CALLBACK_WSI_DESTROY:
+        case LWS_CALLBACK_WSI_DESTROY: {
             DBUS_BROKER_WARNING("WS client session closed %s", "");
             free_dlinks();
             break;
+        }
 
         default:
             break;


### PR DESCRIPTION
1. A couple of cases in one of the switch statements from `dbus.c` had inconsistent bracketing
2. Legacy linking to `libv4v` in the `Makefile.am`
3. Move commented out debugging code to separate functions.
4. Removes legacy functions no longer used and adjusts declaration of other functions(e.g. static).